### PR TITLE
Conversion between Ruby objects and standard message types

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ Developing
 Build message classes: `rake compile`
 
 Run tests: `rake test`
+
+Releases follow [SemVer](http://semver.org/).

--- a/Rakefile
+++ b/Rakefile
@@ -47,3 +47,12 @@ task :clean do
     ::FileUtils.rm(file)
   end
 end
+
+desc 'Open a console with this gem loaded'
+task :console do
+  require 'irb'
+  require 'irb/completion'
+  require 'protip'
+  ARGV.clear
+  IRB.start
+end

--- a/definitions/protip.proto
+++ b/definitions/protip.proto
@@ -1,0 +1,2 @@
+import public "protip/messages/types.proto"
+import public "protip/messages/wrappers.proto"

--- a/definitions/protip/messages/types.proto
+++ b/definitions/protip/messages/types.proto
@@ -1,0 +1,7 @@
+package protip;
+
+message Date {
+  required int64 year = 1;
+  required uint32 month = 2;
+  required uint32 day = 3;
+}

--- a/definitions/protip/messages/wrappers.proto
+++ b/definitions/protip/messages/wrappers.proto
@@ -1,0 +1,60 @@
+package protip;
+
+/////
+// Wrappers, copied from https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto
+// These should exactly match the structure of those built-in types, so that users can safely swap them in
+// when upgrading to proto3.
+
+// Wrapper message for double.
+message DoubleValue {
+  // The double value.
+  required double value = 1;
+}
+
+// Wrapper message for float.
+message FloatValue {
+  // The float value.
+  required float value = 1;
+}
+
+// Wrapper message for int64.
+message Int64Value {
+  // The int64 value.
+  required int64 value = 1;
+}
+
+// Wrapper message for uint64.
+message UInt64Value {
+  // The uint64 value.
+  required uint64 value = 1;
+}
+
+// Wrapper message for int32.
+message Int32Value {
+  // The int32 value.
+  required int32 value = 1;
+}
+
+// Wrapper message for uint32.
+message UInt32Value {
+  // The uint32 value.
+  required uint32 value = 1;
+}
+
+// Wrapper message for bool.
+message BoolValue {
+  // The bool value.
+  required bool value = 1;
+}
+
+// Wrapper message for string.
+message StringValue {
+  // The string value.
+  required string value = 1;
+}
+
+// Wrapper message for bytes.
+message BytesValue {
+  // The bytes value.
+  required bytes value = 1;
+}

--- a/lib/protip/converter.rb
+++ b/lib/protip/converter.rb
@@ -1,0 +1,22 @@
+require 'active_support/concern'
+
+
+module Protip
+  module Converter
+    extend ActiveSupport::Concern
+
+    def convertible?(message_class)
+      raise NotImplementedError.new(
+        'Must specify whether a message of a given type can be converted to/from a Ruby object'
+      )
+    end
+
+    def to_object(message)
+      raise NotImplementedError.new('Must convert a message into a Ruby object')
+    end
+
+    def to_message(object, message_class)
+      raise NotImplementedError.new('Must convert a Ruby object into a message of the given type')
+    end
+  end
+end

--- a/lib/protip/message_wrapper.rb
+++ b/lib/protip/message_wrapper.rb
@@ -1,0 +1,70 @@
+require 'active_support/concern'
+require 'protobuf'
+
+module Protip
+  module MessageWrapper
+    extend ActiveSupport::Concern
+
+    attr_reader :message
+    def initialize(message)
+      @message = message
+    end
+
+    def method_missing(name, *args)
+      if (name =~ /=$/ && field = message.class.fields.detect{|field| :"#{field.name}=" == name})
+        raise ArgumentError unless args.length == 1
+        set field, args[0]
+      elsif (field = message.class.fields.detect{|field| field.name == name})
+        raise ArgumentError unless args.length == 0
+        get field
+      else
+        super
+      end
+    end
+
+    module ClassMethods
+      def convertible?(type_class)
+        raise NotImplementedError.new(
+          'Must specify whether a message of a given type can be converted to/from a Ruby object'
+        )
+      end
+
+      def to_object(message)
+        raise NotImplementedError.new('Must convert a message into a Ruby object')
+      end
+
+      def to_message(object, type_class)
+        raise NotImplementedError.new('Must convert a Ruby object into a message of the given type')
+      end
+    end
+
+    private
+
+    def get(field)
+      if field.is_a?(Protobuf::Field::MessageField)
+        if self.class.convertible?(field.type_class)
+          self.class.to_object message[field.name]
+        else
+          self.class.new message[field.name]
+        end
+      else
+        message[field.name]
+      end
+    end
+
+    def set(field, value)
+      if field.is_a?(Protobuf::Field::MessageField)
+        if value.is_a? Protobuf::Message
+          message[field.name]
+        elsif self.class.convertible?(field.type_class)
+          message[field.name] = self.class.to_message value, field.type_class
+        else
+          raise ArgumentError.new "Cannot convert from Ruby object: \"#{field}\""
+        end
+      else
+        message[field.name] = value
+      end
+    end
+  end
+
+end

--- a/lib/protip/messages/types.pb.rb
+++ b/lib/protip/messages/types.pb.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf/message'
+
+module Protip
+
+  ##
+  # Message Classes
+  #
+  class Date < ::Protobuf::Message; end
+
+
+  ##
+  # Message Fields
+  #
+  class Date
+    required :int64, :year, 1
+    required :uint32, :month, 2
+    required :uint32, :day, 3
+  end
+
+end
+

--- a/lib/protip/messages/wrappers.pb.rb
+++ b/lib/protip/messages/wrappers.pb.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf/message'
+
+module Protip
+
+  ##
+  # Message Classes
+  #
+  class DoubleValue < ::Protobuf::Message; end
+  class FloatValue < ::Protobuf::Message; end
+  class Int64Value < ::Protobuf::Message; end
+  class UInt64Value < ::Protobuf::Message; end
+  class Int32Value < ::Protobuf::Message; end
+  class UInt32Value < ::Protobuf::Message; end
+  class BoolValue < ::Protobuf::Message; end
+  class StringValue < ::Protobuf::Message; end
+  class BytesValue < ::Protobuf::Message; end
+
+
+  ##
+  # Message Fields
+  #
+  class DoubleValue
+    required :double, :value, 1
+  end
+
+  class FloatValue
+    required :float, :value, 1
+  end
+
+  class Int64Value
+    required :int64, :value, 1
+  end
+
+  class UInt64Value
+    required :uint64, :value, 1
+  end
+
+  class Int32Value
+    required :int32, :value, 1
+  end
+
+  class UInt32Value
+    required :uint32, :value, 1
+  end
+
+  class BoolValue
+    required :bool, :value, 1
+  end
+
+  class StringValue
+    required :string, :value, 1
+  end
+
+  class BytesValue
+    required :bytes, :value, 1
+  end
+
+end
+

--- a/lib/protip/standard_converter.rb
+++ b/lib/protip/standard_converter.rb
@@ -1,0 +1,75 @@
+require 'protip/converter'
+
+require 'protobuf'
+require 'protip/messages/types.pb'
+require 'protip/messages/wrappers.pb'
+
+module Protip
+  class StandardConverter
+    include Protip::Converter
+
+    class << self
+      attr_reader :conversions
+    end
+    @conversions = {}
+
+    ## Protip types
+    @conversions[Protip::Date] = {
+      to_object: ->(message) { ::Date.new(message.year, message.month, message.day) },
+      to_message: lambda do |date|
+        raise ArgumentError unless date.is_a?(::Date)
+        Protip::Date.new year: date.year, month: date.month, day: date.day
+      end
+    }
+
+    ## Standard wrappers
+    [Protip::Int64Value, Protip::Int32Value, Protip::UInt64Value, Protip::UInt32Value].each do |message_class|
+      @conversions[message_class] = {
+        to_object: ->(message) { message.value },
+        to_message: lambda do |integer|
+          raise ArgumentError unless integer.is_a?(Integer)
+          message_class.new value: integer
+        end
+      }
+    end
+    [Protip::DoubleValue, Protip::FloatValue].each do |message_class|
+      @conversions[message_class] = {
+        to_object: ->(message) { message.value },
+        to_message: lambda do |float|
+          raise ArgumentError unless float.is_a?(Float)
+          message_class.new value: float
+        end
+      }
+    end
+    [Protip::BoolValue].each do |message_class|
+      @conversions[message_class] = {
+        to_object: ->(message) { message.value },
+        to_message: lambda do |bool|
+          # Protobuf throws a type error if this isn't the correct type, so we don't need to check
+          message_class.new value: bool
+        end
+      }
+    end
+    [Protip::StringValue, Protip::BytesValue].each do |message_class|
+      @conversions[message_class] = {
+        to_object: ->(message) { message.value },
+        to_message: lambda do |string|
+          # Protobuf throws a type error if this isn't the correct type, so we don't need to check
+          message_class.new value: string
+        end
+      }
+    end
+
+    def convertible?(message_class)
+      self.class.conversions.has_key?(message_class)
+    end
+
+    def to_object(message)
+      self.class.conversions[message.class][:to_object].call(message)
+    end
+
+    def to_message(object, message_class)
+      self.class.conversions[message_class][:to_message].call(object)
+    end
+  end
+end

--- a/lib/protip/wrapper.rb
+++ b/lib/protip/wrapper.rb
@@ -9,6 +9,18 @@ module Protip
       @converter = converter
     end
 
+    def respond_to?(name)
+      if super
+        true
+      else
+        if name =~ /=$/
+          message.class.fields.any?{|field| :"#{field.name}=" == name.to_sym}
+        else
+          message.class.fields.any?{|field| field.name == name.to_sym}
+        end
+      end
+    end
+
     def method_missing(name, *args)
       if (name =~ /=$/ && field = message.class.fields.detect{|field| :"#{field.name}=" == name})
         raise ArgumentError unless args.length == 1
@@ -28,6 +40,10 @@ module Protip
         json[name.to_s] = value.respond_to?(:as_json) ? value.as_json : value
       end
       json
+    end
+
+    def ==(wrapper)
+      message == wrapper.message && converter == wrapper.converter
     end
 
     private

--- a/test/unit/protip/standard_converter_test.rb
+++ b/test/unit/protip/standard_converter_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+require 'protip/standard_converter'
+
+describe Protip::StandardConverter do
+  let(:converter) { Protip::StandardConverter.new }
+
+  let(:integer_types) do
+    [Protip::Int64Value, Protip::Int32Value, Protip::UInt64Value, Protip::UInt32Value]
+  end
+
+  let(:float_types) do
+    [Protip::FloatValue, Protip::DoubleValue]
+  end
+
+  let(:bool_types) do
+    [Protip::BoolValue]
+  end
+
+  let(:string_types) do
+    [Protip::StringValue, Protip::BytesValue]
+  end
+
+
+  describe '#convertible?' do
+    it 'converts all standard types' do
+      (integer_types + float_types + string_types + bool_types + [Protip::Date]).each do |message_class|
+        assert converter.convertible?(message_class), 'expected type not convertible'
+      end
+    end
+
+    it 'does not convert other message types' do
+      refute converter.convertible?(Class.new(::Protobuf::Message))
+    end
+  end
+
+  describe '#to_object' do
+    it 'converts wrapper types' do
+      {
+        6      => integer_types,
+        5.5    => float_types,
+        false  => bool_types,
+        'asdf' => string_types,
+      }.each do |value, message_types|
+        message_types.each do |message_class|
+          assert_equal value, converter.to_object(message_class.new value: value)
+        end
+      end
+    end
+
+    it 'converts dates' do
+      date = converter.to_object(Protip::Date.new year: 2015, month: 2, day: 9)
+      assert_instance_of Date, date
+      assert_equal 'Mon, 09 Feb 2015', date.inspect
+    end
+  end
+
+  describe '#to_message' do
+    it 'converts wrapper types' do
+      {
+        6      => integer_types,
+        5.5    => float_types,
+        false  => bool_types,
+        'asdf' => string_types,
+      }.each do |value, message_types|
+        message_types.each do |message_class|
+          assert_equal message_class.new(value: value), converter.to_message(value, message_class)
+        end
+      end
+    end
+
+    it 'converts dates' do
+      date = ::Date.new(2012, 5, 7)
+      assert_equal 7, date.day # Sanity check argument order
+      assert_equal Protip::Date.new(year: 2012, month: 5, day: 7), converter.to_message(date, Protip::Date)
+    end
+  end
+end

--- a/test/unit/protip/wrapper_test.rb
+++ b/test/unit/protip/wrapper_test.rb
@@ -2,7 +2,100 @@ require 'test_helper'
 
 require 'protip/wrapper'
 
-class Protip::WrapperTest
+module Protip::WrapperTest # namespace for internal constants
   describe Protip::Wrapper do
+    let(:converter) do
+      Class.new do
+        include Protip::Converter
+      end.new
+    end
+
+    class InnerMessage < ::Protobuf::Message
+      required :int64, :value, 1
+    end
+    class Message < ::Protobuf::Message
+      optional InnerMessage, :inner, 1
+      optional :string, :string, 2
+    end
+
+    let(:wrapped_message) do
+      Message.new(inner: {value: 25}, string: 'test')
+    end
+
+    let(:wrapper) do
+      Protip::Wrapper.new(wrapped_message, converter)
+    end
+
+    describe '#respond_to?' do
+      it 'adds setters for message fields' do
+        assert_respond_to wrapper, :string=
+        assert_respond_to wrapper, :inner=
+      end
+      it 'adds getters for message fields' do
+        assert_respond_to wrapper, :string
+        assert_respond_to wrapper, :inner
+      end
+      it 'responds to standard defined methods' do
+        assert_respond_to wrapper, :as_json
+      end
+      it 'does not add other setters/getters' do
+        refute_respond_to wrapper, :foo=
+        refute_respond_to wrapper, :foo
+      end
+    end
+
+    describe '#get' do
+      it 'does not convert simple fields' do
+        converter.expects(:convertible?).never
+        converter.expects(:to_object).never
+        assert_equal 'test', wrapper.string
+      end
+
+      it 'converts convertible messages' do
+        converter.expects(:convertible?).with(InnerMessage).once.returns(true)
+        converter.expects(:to_object).with(InnerMessage.new(value: 25)).returns 40
+        assert_equal 40, wrapper.inner
+      end
+
+      it 'wraps inconvertible messages' do
+        converter.expects(:convertible?).with(InnerMessage).once.returns(false)
+        converter.expects(:to_object).never
+        assert_equal Protip::Wrapper.new(InnerMessage.new(value: 25), converter), wrapper.inner
+      end
+    end
+
+    describe '#set' do
+      it 'does not convert simple fields' do
+        converter.expects(:convertible?).never
+        converter.expects(:to_message).never
+
+        wrapper.string = 'test2'
+        assert_equal 'test2', wrapper.message.string
+      end
+
+      it 'converts convertible messages' do
+        converter.expects(:convertible?).with(InnerMessage).once.returns(true)
+        converter.expects(:to_message).with(40, InnerMessage).returns(InnerMessage.new(value: 30))
+
+        wrapper.inner = 40
+        assert_equal InnerMessage.new(value: 30), wrapper.message.inner
+      end
+
+      it 'raises an error when setting inconvertible messages' do
+        converter.expects(:convertible?).with(InnerMessage).once.returns(false)
+        converter.expects(:to_message).never
+        assert_raises ArgumentError do
+          wrapper.inner = 'cannot convert me'
+        end
+      end
+
+      it 'passes through messages without checking whether they are convertible' do
+        converter.expects(:convertible?).never
+        converter.expects(:to_message).never
+
+        wrapper.inner = InnerMessage.new(value: 50)
+        assert_equal InnerMessage.new(value: 50), wrapper.message.inner
+      end
+    end
   end
 end

--- a/test/unit/protip/wrapper_test.rb
+++ b/test/unit/protip/wrapper_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+require 'protip/wrapper'
+
+class Protip::WrapperTest
+  describe Protip::Wrapper do
+  end
+end


### PR DESCRIPTION
Adds a `Protip::Wrapper` class which wraps a message and provides conversion to/from Ruby objects when using getters/setters. When conversion isn't available in the getter case, returns a wrapped version of the nested message.

Also adds a `Protip::Converter` concern and `Protip::StandardConverter` class which serves as the default converter between Ruby objects and messages. The standard converter provides conversion for `Date`s as well as the standard types defined in https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto (the idea is that we'll remove our standard type wrappers once proto3 is released). This prepares us well for proto3.

Overall, this means that the following proto definition:

```
message Outer {
  message Inner {
    optional Date date = 1;
  }
  optional Inner inner = 1;
}
```

Could be used in a resource like this:

```
resource = OuterResource.new(inner: {})
resource.inner.date = Date.today
resource.inner.date # gives Date.today
```

The big remaining thing to figure out is how/when to construct nested messages - currently the way it works is to pass an empty hash at construction (e.g. `inner: {}` in the example above), or to manually build the nested message (e.g. `resource.inner = Outer::Inner.new`), which requires you to know verbose details like the message type. We might want to allow something like `resource.build(:inner, attrs)`.