### PR TITLE
Enum queries

### DIFF
--- a/lib/protip/resource.rb
+++ b/lib/protip/resource.rb
@@ -165,6 +165,9 @@ module Protip
         @message.descriptor.each do |field|
           def_delegator :@wrapper, :"#{field.name}"
           def_delegator :@wrapper, :"#{field.name}="
+          if ::Protip::Wrapper.matchable?(field)
+            def_delegator :@wrapper, :"#{field.name}?"
+          end
         end
 
         # Validate arguments

--- a/lib/protip/wrapper.rb
+++ b/lib/protip/wrapper.rb
@@ -17,10 +17,10 @@ module Protip
       if super
         true
       else
-        if name =~ /=$/
-          message.class.descriptor.any?{|field| :"#{field.name}=" == name.to_sym}
-        else
-          message.class.descriptor.any?{|field| field.name.to_sym == name.to_sym}
+        message.class.descriptor.any? do |field|
+          # getter, setter, and in the scalar enum case, query method
+          regex = /^#{field.name}[=#{allows_match?(field) ? '\\?' : ''}]?$/
+          name.to_s =~ regex
         end
       end
     end
@@ -29,6 +29,9 @@ module Protip
       if (name =~ /=$/ && field = message.class.descriptor.detect{|field| :"#{field.name}=" == name})
         raise ArgumentError unless args.length == 1
         set field, args[0]
+      elsif (name =~ /\?$/ && field = message.class.descriptor.detect{|field| allows_match?(field) && :"#{field.name}?" == name})
+        raise ArgumentError unless args.length == 1
+        matches? field, args[0]
       elsif (field = message.class.descriptor.detect{|field| field.name.to_sym == name})
         raise ArgumentError unless args.length == 0
         get field
@@ -183,6 +186,23 @@ module Protip
       else
         value
       end
+    end
+
+    def matches?(field, value)
+      enum = field.subtype
+      if value.is_a?(Fixnum)
+        sym = enum.lookup_value(value)
+      else
+        sym = value.to_sym
+        sym = nil if (nil == enum.lookup_name(sym))
+      end
+      raise RangeError.new("#{field} has no value #{value}") if nil == sym
+      get(field) == sym
+
+    end
+
+    def allows_match?(field)
+      field.type == :enum && field.label != :repeated
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
 require 'minitest/autorun'
 require 'mocha/mini_test'
 require 'webmock/minitest'
+
+require 'minitest/pride'


### PR DESCRIPTION
Adds query methods for enums to wrappers and resources, so wrapping a message like:

```
message Foo {
  enum Bar {
    BAZ = 0;
    QUX = 1;
  }
  Bar bar = 1;
}
```

would allow calls like:

```ruby
wrapper = Protip::Wrapper.new(Foo::Bar.new, converter)
wrapper.bar?(:BAZ) # => true
wrapper.bar?(:QUX) # => false
wrapper.bar?(:QUUX) # => raises RangeError
```