### PR TITLE
More informative error messages without having to inspect the error object

### DIFF
--- a/lib/protip/error.rb
+++ b/lib/protip/error.rb
@@ -5,14 +5,27 @@ require 'protip/messages/errors.pb'
 
 module Protip
   class Error < RuntimeError
-    attr_reader :request, :response
-    def initialize(request, response)
+    attr_reader :request, :response, :message
+    def initialize(request, response, message=nil)
       @request = request
       @response = response
+      @message = message
     end
 
     def inspect
       "[#{self.class}] #{request.uri} -> code #{response.code}"
+    end
+
+    def default_message
+      [
+        "request uri: #{request.uri}",
+        "response code: #{response.code}",
+        "response body: #{response.body}"
+      ].join("\n")
+    end
+
+    def to_s
+      message || default_message
     end
   end
 
@@ -24,12 +37,17 @@ module Protip
     end
   end
 
+  # Raised when we have a 422 response from the server.
   class UnprocessableEntityError < Error
     # Get the parsed errors object from a 422 response.
     #
     # @return ::Protip::Messages::Errors
     def errors
       ::Protip::Messages::Errors.decode response.body
+    end
+
+    def to_s
+      message || errors.to_s
     end
   end
 

--- a/protip.gemspec
+++ b/protip.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = 'protip'
-  spec.version       = '0.10.5'
+  spec.version       = '0.10.6'
   spec.summary       = 'ActiveModel resources backed by protocol buffers'
   spec.licenses      = ['MIT']
   spec.homepage      = 'https://github.com/AngelList/protip'
@@ -14,7 +14,10 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activemodel', '>= 3.0.0', '< 5.0'
   spec.add_runtime_dependency 'activesupport', '>= 3.0.0', '< 5.0'
-  spec.add_runtime_dependency 'protobuf', '~> 3.5'
+
+  # Temporarily restricted. Protobuf bumped their dependency on multi_json, which is causing
+  # problems with compass.
+  spec.add_runtime_dependency 'protobuf', '~> 3.5.0'
 
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'mocha', '~> 1.1'

--- a/protip.gemspec
+++ b/protip.gemspec
@@ -15,9 +15,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activemodel', '>= 3.0.0', '< 5.0'
   spec.add_runtime_dependency 'activesupport', '>= 3.0.0', '< 5.0'
 
-  # Temporarily restricted. Protobuf bumped their dependency on multi_json, which is causing
-  # problems with compass.
-  spec.add_runtime_dependency 'protobuf', '~> 3.5.0'
+  spec.add_runtime_dependency 'protobuf', '~> 3.5'
 
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'mocha', '~> 1.1'


### PR DESCRIPTION
* Adds `Protip::Error#to_s`, 
* Creates a default error message including request uri, response code, and response body
* Adds support for custom messages when raising exception (might not be needed now)

This leads to far more informative error messages in logs and in error tracking services like Rollbar.