### PR TITLE
Improve Resource and Wrapper code organization

### DIFF
--- a/lib/protip/resource/creatable.rb
+++ b/lib/protip/resource/creatable.rb
@@ -1,0 +1,18 @@
+module Protip
+  module Resource
+    # Mixin for a resource that has an active `:create` action. Should be treated as private,
+    # and will be included automatically when appropriate.
+    module Creatable
+      private
+      # POST the resource to the server and update our internal message. Private, since
+      # we should generally do this through the `save` method.
+      def create!
+        raise RuntimeError.new("Can't re-create a persisted object") if persisted?
+        self.message = self.class.client.request path: self.class.base_path,
+          method: Net::HTTP::Post,
+          message: message,
+          response_type: self.class.message
+      end
+    end
+  end
+end

--- a/lib/protip/resource/destroyable.rb
+++ b/lib/protip/resource/destroyable.rb
@@ -1,0 +1,15 @@
+module Protip
+  module Resource
+    # Mixin for a resource that has an active `:destroy` action. Should be treated as private,
+    # and will be included automatically when appropriate.
+    module Destroyable
+      def destroy
+        raise RuntimeError.new("Can't destroy a non-persisted object") if !persisted?
+        self.message = self.class.client.request path: "#{self.class.base_path}/#{id}",
+          method: Net::HTTP::Delete,
+          message: nil,
+          response_type: self.class.message
+      end
+    end
+  end
+end

--- a/lib/protip/resource/extra_methods.rb
+++ b/lib/protip/resource/extra_methods.rb
@@ -1,0 +1,23 @@
+module Protip
+  module Resource
+    # Internal helpers for non-resourceful member/collection methods. Never use these directly;
+    # instead, use the instance/class methods which have been dynamically defined on the resource
+    # you're working with.
+    module ExtraMethods
+      def self.member(resource, action, method, message, response_type)
+        response = resource.class.client.request path: "#{resource.class.base_path}/#{resource.id}/#{action}",
+          method: method,
+          message: message,
+          response_type: response_type
+        nil == response ? nil : ::Protip::Wrapper.new(response, resource.class.converter)
+      end
+      def self.collection(resource_class, action, method, message, response_type)
+        response = resource_class.client.request path: "#{resource_class.base_path}/#{action}",
+          method: method,
+          message: message,
+          response_type: response_type
+        nil == response ? nil : ::Protip::Wrapper.new(response, resource_class.converter)
+      end
+    end
+  end
+end

--- a/lib/protip/resource/search_methods.rb
+++ b/lib/protip/resource/search_methods.rb
@@ -1,0 +1,40 @@
+module Protip
+  module Resource
+    # Internal handlers for index/show actions. Never use these directly; instead, use `.all` and
+    # `.find` on the resource you're working with, since those methods will adjust their
+    # signatures to correctly parse a set of query parameters if supported.
+    module SearchMethods
+      # Fetch a list from the server at the collection's base endpoint. Expects the server response
+      # to be an array containing encoded messages that can be used to instantiate our resource.
+      #
+      # @param resource_class [Class] The resource type that we're fetching.
+      # @param query [::Protobuf::Message|NilClass] An optional query to send along with the request.
+      # @return [Array] The array of resources (each is an instance of the resource class we were
+      #   initialized with).
+      def self.index(resource_class, query)
+        response = resource_class.client.request path: resource_class.base_path,
+          method: Net::HTTP::Get,
+          message: query,
+          response_type: Protip::Messages::Array
+        response.messages.map do |message|
+          resource_class.new resource_class.message.decode(message)
+        end
+      end
+
+      # Fetch a single resource from the server.
+      #
+      # @param resource_class [Class] The resource type that we're fetching.
+      # @param id [String] The ID to be used in the URL to fetch the resource.
+      # @param query [::Protobuf::Message|NilClass] An optional query to send along with the request.
+      # @return [Protip::Resource] An instance of our resource class, created from the server
+      #   response.
+      def self.show(resource_class, id, query)
+        response = resource_class.client.request path: "#{resource_class.base_path}/#{id}",
+          method: Net::HTTP::Get,
+          message: query,
+          response_type: resource_class.message
+        resource_class.new response
+      end
+    end
+  end
+end

--- a/lib/protip/resource/updateable.rb
+++ b/lib/protip/resource/updateable.rb
@@ -1,0 +1,19 @@
+module Protip
+  module Resource
+    # Mixin for a resource that has an active `:update` action. Should be treated as private,
+    # and will be included automatically when appropriate.
+    module Updatable
+      private
+      # PUT the resource on the server and update our internal message. Private, since
+      # we should generally do this through the `save` method.
+      def update!
+        raise RuntimeError.new("Can't update a non-persisted object") if !persisted?
+        self.message = self.class.client.request path: "#{self.class.base_path}/#{id}",
+          method: Net::HTTP::Put,
+          message: message,
+          response_type: self.class.message
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
1. Moves Resource submodules into separate files
2. Breaks up Resource.resource into smaller methods
3. Breaks up Wrapper#method_missing into smaller methods
4. Minor other improvements (e.g. use of constant for actions list, etc.)