### PR TITLE
Add support for nested resources

### DIFF
--- a/lib/protip/wrapper.rb
+++ b/lib/protip/wrapper.rb
@@ -204,6 +204,8 @@ module Protip
       if field.type == :message
         if nil == value
           nil
+        # This check must happen before the nested_resources check to ensure nested messages
+        # are set properly
         elsif value.is_a?(field.subtype.msgclass)
           value
         elsif converter.convertible?(field.subtype.msgclass)

--- a/protip.gemspec
+++ b/protip.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = 'protip'
-  spec.version       = '0.13.2'
+  spec.version       = '0.14.0'
   spec.summary       = 'ActiveModel resources backed by protocol buffers'
   spec.licenses      = ['MIT']
   spec.homepage      = 'https://github.com/AngelList/protip'

--- a/test/unit/protip/wrapper_test.rb
+++ b/test/unit/protip/wrapper_test.rb
@@ -65,13 +65,6 @@ module Protip::WrapperTest # namespace for internal constants
       mock.responds_like_instance_of(Class.new { include Protip::Client })
     end
 
-    let :converter do
-      Class.new do
-        include Protip::Converter
-      end.new
-    end
-
-
     # Call `resource_class` to get an empty resource type.
     let :resource_class do
       resource_class = Class.new do

--- a/test/unit/protip/wrapper_test.rb
+++ b/test/unit/protip/wrapper_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 require 'google/protobuf'
-require 'protip/converter'
 require 'protip/wrapper'
+require 'protip/resource'
 
 module Protip::WrapperTest # namespace for internal constants
   describe Protip::Wrapper do
@@ -58,6 +58,31 @@ module Protip::WrapperTest # namespace for internal constants
       let(:"#{name}_class") do
         pool.lookup(name).msgclass
       end
+    end
+
+    # Stubbed API client
+    let :client do
+      mock.responds_like_instance_of(Class.new { include Protip::Client })
+    end
+
+    let :converter do
+      Class.new do
+        include Protip::Converter
+      end.new
+    end
+
+
+    # Call `resource_class` to get an empty resource type.
+    let :resource_class do
+      resource_class = Class.new do
+        include Protip::Resource
+        self.base_path = 'base_path'
+        class << self
+          attr_accessor :client
+        end
+      end
+      resource_class.client = client
+      resource_class
     end
 
     let(:wrapped_message) do
@@ -346,6 +371,13 @@ module Protip::WrapperTest # namespace for internal constants
     end
 
     describe '#get' do
+      before do
+        resource_class.class_exec(converter, inner_message_class) do |converter, message|
+          resource actions: [], message: message
+          self.converter = converter
+        end
+      end
+
       it 'does not convert simple fields' do
         converter.expects(:convertible?).never
         converter.expects(:to_object).never
@@ -364,6 +396,14 @@ module Protip::WrapperTest # namespace for internal constants
         assert_equal Protip::Wrapper.new(inner_message_class.new(value: 25), converter), wrapper.inner
       end
 
+      it 'wraps nested resource messages in their defined resource' do
+        message = wrapped_message
+        klass = resource_class
+        wrapper = Protip::Wrapper.new(message, Protip::StandardConverter.new, {inner: klass})
+        assert_equal klass, wrapper.inner.class
+        assert_equal message.inner, wrapper.inner.message
+      end
+
       it 'returns nil for messages that have not been set' do
         converter.expects(:convertible?).never
         converter.expects(:to_object).never
@@ -372,6 +412,14 @@ module Protip::WrapperTest # namespace for internal constants
     end
 
     describe 'attribute writer' do # generated via method_missing?
+
+      before do
+        resource_class.class_exec(converter, inner_message_class) do |converter, message|
+          resource actions: [], message: message
+          self.converter = converter
+        end
+      end
+
       it 'does not convert simple fields' do
         converter.expects(:convertible?).never
         converter.expects(:to_message).never
@@ -412,6 +460,20 @@ module Protip::WrapperTest # namespace for internal constants
         converter.expects(:to_message).never
         wrapper.inner = message
         assert_equal inner_message_class.new(value: 50), wrapper.message.inner
+      end
+
+      it 'for nested resources, sets the resource\'s message' do
+        message = wrapped_message
+        klass = resource_class
+        new_inner_message = inner_message_class.new(value: 50)
+
+        resource = klass.new new_inner_message
+        wrapper = Protip::Wrapper.new(message, Protip::StandardConverter.new, {inner: klass})
+
+        resource.expects(:message).once.returns(new_inner_message)
+        wrapper.inner = resource
+
+        assert_equal new_inner_message, wrapper.message.inner
       end
 
       it 'raises an error when setting an enum field to an undefined value' do

--- a/test/unit/protip/wrapper_test.rb
+++ b/test/unit/protip/wrapper_test.rb
@@ -466,7 +466,10 @@ module Protip::WrapperTest # namespace for internal constants
         resource.expects(:message).once.returns(new_inner_message)
         wrapper.inner = resource
 
-        assert_equal new_inner_message, wrapper.message.inner
+        assert_equal new_inner_message,
+                     wrapper.message.inner,
+                     'Wrapper did not set its message\'s inner message value to the value of the '\
+                     'given resource\'s message'
       end
 
       it 'raises an error when setting an enum field to an undefined value' do


### PR DESCRIPTION
At time of resource definition, support defining a mapping of `message field name` => `Protip::Resource class` that will be used to wrap those message fields in the defined Resource. 

The nested resources will behave identically to resources instantiated manually with the same message.