### PR TITLE
Mimic rails boolean value behavior in StandardConverter

### DIFF
--- a/lib/protip/standard_converter.rb
+++ b/lib/protip/standard_converter.rb
@@ -6,7 +6,7 @@ module Protip
   class StandardConverter
     include Protip::Converter
 
-    TRUTH_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE', 'on', 'ON']
+    TRUE_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE', 'on', 'ON']
     FALSE_VALUES = [false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF']
 
     class << self
@@ -55,7 +55,7 @@ module Protip
     class << self
       # Similar to Rails 3 value_to_boolean
       def value_to_boolean(value)
-        return true if TRUTH_VALUES.include?(value)
+        return true if TRUE_VALUES.include?(value)
         return false if FALSE_VALUES.include?(value)
         # If we don't get a truthy/falsey value, use the original value (which should raise an
         # exception)

--- a/lib/protip/standard_converter.rb
+++ b/lib/protip/standard_converter.rb
@@ -6,8 +6,8 @@ module Protip
   class StandardConverter
     include Protip::Converter
 
-    TRUTH_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE']
-    FALSE_VALUES = [nil, false, 0, '0', 'f', 'F', 'false', 'FALSE']
+    TRUTH_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE', 'on', 'ON']
+    FALSE_VALUES = [false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF']
 
     class << self
       attr_reader :conversions

--- a/protip.gemspec
+++ b/protip.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = 'protip'
-  spec.version       = '0.14.0'
+  spec.version       = '0.15.0'
   spec.summary       = 'ActiveModel resources backed by protocol buffers'
   spec.licenses      = ['MIT']
   spec.homepage      = 'https://github.com/AngelList/protip'

--- a/test/unit/protip/standard_converter_test.rb
+++ b/test/unit/protip/standard_converter_test.rb
@@ -85,21 +85,21 @@ describe Protip::StandardConverter do
     end
 
     it 'converts truthy values to booleans' do
-      [true, 1, '1', 't', 'T', 'true', 'TRUE'].each do |truth_value|
+      [true, 1, '1', 't', 'T', 'true', 'TRUE', 'on', 'ON'].each do |truth_value|
         assert_equal Google::Protobuf::BoolValue.new(value: true),
                      converter.to_message(truth_value, Google::Protobuf::BoolValue)
       end
     end
 
     it 'converts falsey values to booleans' do
-      [nil, false, 0, '0', 'f', 'F', 'false', 'FALSE'].each do |false_value|
+      [false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF'].each do |false_value|
         assert_equal Google::Protobuf::BoolValue.new(value: false),
                      converter.to_message(false_value, Google::Protobuf::BoolValue)
       end
     end
 
     it 'raises an exception if non-boolean values passed to boolean field' do
-      ['test', Object.new, 2, {}, []].each do |bad_value|
+      [nil, 'test', Object.new, 2, {}, []].each do |bad_value|
         assert_raises TypeError do
           converter.to_message(bad_value, Google::Protobuf::BoolValue)
         end

--- a/test/unit/protip/standard_converter_test.rb
+++ b/test/unit/protip/standard_converter_test.rb
@@ -83,5 +83,28 @@ describe Protip::StandardConverter do
       assert_equal 7, date.day # Sanity check argument order
       assert_equal ::Protip::Messages::Date.new(year: 2012, month: 5, day: 7), converter.to_message(date, ::Protip::Messages::Date)
     end
+
+    it 'converts truthy values to booleans' do
+      [true, 1, '1', 't', 'T', 'true', 'TRUE'].each do |truth_value|
+        assert_equal Google::Protobuf::BoolValue.new(value: true),
+                     converter.to_message(truth_value, Google::Protobuf::BoolValue)
+      end
+    end
+
+    it 'converts falsey values to booleans' do
+      [nil, false, 0, '0', 'f', 'F', 'false', 'FALSE'].each do |false_value|
+        assert_equal Google::Protobuf::BoolValue.new(value: false),
+                     converter.to_message(false_value, Google::Protobuf::BoolValue)
+      end
+    end
+
+    it 'raises an exception if non-boolean values passed to boolean field' do
+      ['test', Object.new, 2, {}, []].each do |bad_value|
+        assert_raises TypeError do
+          converter.to_message(bad_value, Google::Protobuf::BoolValue)
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Allows for setting of boolean values with truthy/falsey values. Behavior modeled off of Rails 4. For example:

`MyResource.new(example_boolean_value: 'true')` will set the field value to true rather than throwing a TypeError