### PR TITLE
Fix nil bug for enum fields

### DIFF
--- a/lib/protip/wrapper.rb
+++ b/lib/protip/wrapper.rb
@@ -216,7 +216,7 @@ module Protip
           raise ArgumentError.new "Cannot convert from Ruby object: \"#{field}\""
         end
       elsif field.type == :enum
-        value.is_a?(Fixnum) ? value : value.to_sym
+        value.is_a?(Fixnum) ? value : value.try(:to_sym)
       else
         value
       end

--- a/lib/protip/wrapper.rb
+++ b/lib/protip/wrapper.rb
@@ -216,7 +216,14 @@ module Protip
           raise ArgumentError.new "Cannot convert from Ruby object: \"#{field}\""
         end
       elsif field.type == :enum
-        value.is_a?(Fixnum) ? value : value.try(:to_sym)
+        if nil == value
+          # Enum fields can't be nil. Enum 0 is the default value.
+          0
+        elsif value.is_a?(Fixnum)
+          value
+        else
+          value.to_sym
+        end
       else
         value
       end

--- a/lib/protip/wrapper.rb
+++ b/lib/protip/wrapper.rb
@@ -217,7 +217,7 @@ module Protip
         end
       elsif field.type == :enum
         if nil == value
-          # Enum fields can't be nil. Enum 0 is the default value.
+          # Enum fields can't be nil. The 0th enum is the default value.
           0
         elsif value.is_a?(Fixnum)
           value

--- a/test/unit/protip/wrapper_test.rb
+++ b/test/unit/protip/wrapper_test.rb
@@ -478,6 +478,16 @@ module Protip::WrapperTest # namespace for internal constants
         end
       end
 
+      it 'allows enum fields to be set to nil' do
+        # first set `number` and assert that it's set
+        wrapper.number = :ONE
+        assert_equal :ONE, wrapper.number
+
+        # now test that it can be set to nil
+        wrapper.number = nil
+        assert_equal :ZERO, wrapper.number
+      end
+
       it 'allows strings to be set for enum fields' do
         wrapper.number = 'ONE'
         assert_equal :ONE, wrapper.number


### PR DESCRIPTION
Before this fix:

```
[2] ipseity-dev(main)> ::EntityAPI::Accreditation::UnitedStates::SelfCertification.new asset_level: nil
NoMethodError: undefined method `to_sym' for nil:NilClass
from /app/vendor/bundle/gems/protip-0.15.0/lib/protip/wrapper.rb:219:in `to_protobuf_value'
```

After this fix, the enum field will be set to the 0th field value. Right or wrong, this is more consistent w/ how protobufs work. See: https://developers.google.com/protocol-buffers/docs/proto?hl=en#optional

For example, if you initialize an empty resource right now, you get:

```
[4] ipseity-dev(main)> ::EntityAPI::Accreditation::UnitedStates::SelfCertification.new
=> #<EntityAPI::Accreditation::UnitedStates::SelfCertification:0x007fa5c4f35c48
 @wrapper=
  #<Protip::Wrapper:0x007fa5c4f35ae0
   @converter=
    #<EntityAPI::Converter:0x007fa5c4faab88 @standard_converter=#<ProxyAPI::Converter:0x007fa5c4faab38 @standard_converter=#<Protip::StandardConverter:0x007fa5c4faab10>>>,
   @message=<EntityAPI::Messages::Accreditation::UnitedStates::SelfCertification: id: nil, entity_id: nil, asset_level: :ASSET_LEVEL_NOT_SET, basis: :BASIS_NOT_SET>,
   @nested_resources={}>>
```

There's no reason why `::EntityAPI::Accreditation::UnitedStates::SelfCertification.new` should succeed, but `::EntityAPI::Accreditation::UnitedStates::SelfCertification.new asset_level: nil` should fail, IMO.

If we don't do this, our `as_proto` declarations will have to be messier.

```
    ::EntityAPI::Accreditation::UnitedStates::Verifications::ActsLikePerson::Income.new(
        {
            id: id.try(:encode, 'UTF-8'),
            entity_id: entity_id.try(:encode, 'UTF-8'),
            verifier_type: verifier_type.try(:upcase).try(:to_sym),
        }
    )
```

`verifier_type` is an enum so the above code will fail if `verifier_type` is nil. We'd have to do

`verifier_type: verifier_type.try(:upcase).try(:to_sym) || ::EntityAPI::Messages::Accreditation::UnitedStates::Verifications::Shared::VERIFIER_TYPE_NOT_SPECIFIED`