### PR TITLE
Allow assigning scalar values to repeated fields

### DIFF
--- a/lib/protip/wrapper.rb
+++ b/lib/protip/wrapper.rb
@@ -201,6 +201,9 @@ module Protip
 
     def set(field, value)
       if field.label == :repeated
+        if !value.is_a?(Enumerable) # Wrap non-enumerable values to allow assigning scalars
+          value = [value]
+        end
         message[field.name].replace value.map{|v| to_protobuf_value field, v}
       else
         message[field.name] = to_protobuf_value(field, value)

--- a/test/unit/protip/wrapper_test.rb
+++ b/test/unit/protip/wrapper_test.rb
@@ -203,6 +203,11 @@ module Protip::WrapperTest # namespace for internal constants
         assert_equal ['one', 'two'], wrapped_message.strings
       end
 
+      it 'assigns repeated primitive fields as a single-element array when given a scalar' do
+        wrapper.assign_attributes strings: 'one'
+        assert_equal ['one'], wrapped_message.strings
+      end
+
       describe 'when assigning convertible message fields' do
         before do
           converter.stubs(:convertible?).with(inner_message_class).returns(true)
@@ -214,14 +219,22 @@ module Protip::WrapperTest # namespace for internal constants
           assert_equal inner_message_class.new(value: 43), wrapped_message.inner
         end
 
-        it 'converts repeated Ruby values to protobuf messages' do
-          invocation = 0
-          converter.expects(:to_message).twice.with do |value|
-            invocation += 1
-            value == invocation
-          end.returns(inner_message_class.new(value: 43), inner_message_class.new(value: 44))
-          wrapper.assign_attributes inners: [1, 2]
-          assert_equal [inner_message_class.new(value: 43), inner_message_class.new(value: 44)], wrapped_message.inners
+        describe 'when the field is repeated' do
+          it 'converts repeated Ruby values to protobuf messages' do
+            invocation = 0
+            converter.expects(:to_message).twice.with do |value, message_class|
+              invocation += 1
+              value == invocation && message_class == inner_message_class
+            end.returns(inner_message_class.new(value: 43), inner_message_class.new(value: 44))
+            wrapper.assign_attributes inners: [1, 2]
+            assert_equal [inner_message_class.new(value: 43), inner_message_class.new(value: 44)], wrapped_message.inners
+          end
+
+          it 'converts scalar Ruby values to repeated protobuf messages' do
+            converter.expects(:to_message).once.with(1, inner_message_class).returns(inner_message_class.new(value: 42))
+            wrapper.assign_attributes inners: 1
+            assert_equal [inner_message_class.new(value: 42)], wrapped_message.inners
+          end
         end
 
         it 'allows messages to be assigned directly' do


### PR DESCRIPTION
This makes these statements equivalent:

```ruby
SomeResource.all(ids: [3])
SomeResource.all(ids: 3)
```

I'm not actually convinced we should do this. One nasty side effect is that the behavior of convertible enumerable types becomes confusing, e.g. the following statements are not equivalent:

```ruby
SomeResource.all(arrays: [1, 2, 3])
SomeResource.all(arrays: [[1, 2, 3]])
```