### PR TITLE
Update to non-deprecated `respond_to?` method signature

### DIFF
--- a/lib/protip/decorator.rb
+++ b/lib/protip/decorator.rb
@@ -22,7 +22,7 @@ module Protip
       "<#{self.class.name}(#{transformer.class.name}) #{message.inspect}>"
     end
 
-    def respond_to?(name)
+    def respond_to?(name, include_all=false)
       if super
         true
       else

--- a/protip.gemspec
+++ b/protip.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = 'protip'
-  spec.version       = '0.31.0'
+  spec.version       = '0.31.1'
   spec.summary       = 'Relatively painless protocol buffers in Ruby.'
   spec.licenses      = ['MIT']
   spec.homepage      = 'https://github.com/AngelList/protip'


### PR DESCRIPTION
Updates deprecated `respond_to?` method signature, silencing this error:

`warning: Protip::Decorator#respond_to?(X) uses the deprecated method signature, which takes one parameter`