### PR TITLE
Decorator#respond_to? -> Decorator#respond_to_missing?

### DIFF
--- a/lib/protip/decorator.rb
+++ b/lib/protip/decorator.rb
@@ -22,19 +22,17 @@ module Protip
       "<#{self.class.name}(#{transformer.class.name}) #{message.inspect}>"
     end
 
-    def respond_to?(name, include_all=false)
-      if super
-        true
-      else
-        # Responds to calls to oneof groups by name
-        return true if message.class.descriptor.lookup_oneof(name.to_s)
+    def respond_to_missing?(name, *)
+      return true if super
 
-        # Responds to field getters, setters, and query methods for all fieldsfa
-        field = message.class.descriptor.lookup(name.to_s.gsub(/[=?]$/, ''))
-        return false if !field
+      # Responds to calls to oneof groups by name
+      return true if message.class.descriptor.lookup_oneof(name.to_s)
 
-        true
-      end
+      # Responds to field getters, setters, and query methods for all fieldsfa
+      field = message.class.descriptor.lookup(name.to_s.gsub(/[=?]$/, ''))
+      return true if field
+
+      false
     end
 
     def method_missing(name, *args)

--- a/protip.gemspec
+++ b/protip.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = 'protip'
-  spec.version       = '0.31.1'
+  spec.version       = '0.31.2'
   spec.summary       = 'Relatively painless protocol buffers in Ruby.'
   spec.licenses      = ['MIT']
   spec.homepage      = 'https://github.com/AngelList/protip'


### PR DESCRIPTION
Avoids private method delegation errors in ruby 2.4 and provides for correct method behavior (see http://blog.marc-andre.ca/2010/11/15/methodmissing-politely/)