### PR TITLE
Support ActiveModel 5.2+

### DIFF
--- a/lib/protip/resource.rb
+++ b/lib/protip/resource.rb
@@ -358,7 +358,10 @@ module Protip
     # needed for ActiveModel::Dirty in earlier ActiveModel versions
     def changes_applied
       @previously_changed = changes
-      @changed_attributes.clear
+      # @changed_attributes is nil in active_support 5.2+
+      if @changed_attributes.present?
+        @changed_attributes.clear
+      end
     end
   end
 end

--- a/protip.gemspec
+++ b/protip.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = 'protip'
-  spec.version       = '0.32.2'
+  spec.version       = '0.32.3'
   spec.summary       = 'Relatively painless protocol buffers in Ruby.'
   spec.licenses      = ['MIT']
   spec.homepage      = 'https://github.com/AngelList/protip'


### PR DESCRIPTION
This unblocks Rails 5.2 upgrades

`@changed_attributes` can be nil in some versions of ActiveModel. 