### PR TITLE
Add support for sorbet rbi generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
 ## Changelog
 
+### 0.36.1
+
+  * Add support for rbi generation for sorbet
+
 ### 0.36
 
-  * Relax constraints to support Rails 6 
-  
+  * Relax constraints to support Rails 6
+
 ### 0.35.4
 
-  * Relax google-protobuf version constraint 
-  
+  * Relax google-protobuf version constraint
+
 ### 0.35.4
 
-  * Raise the google-protobuf version to 3.7.1 to support Ruby 2.6 
-  
+  * Raise the google-protobuf version to 3.7.1 to support Ruby 2.6
+
 ### 0.35.3
 
   * Lowered the google-protobuf version to 3.6.1
@@ -19,7 +23,7 @@
 ### 0.35.2
 
   * Lowered the minimum google-protobuf version to 3.7.0
-  
+
 ### 0.35.1
 
   * Lowered the minimum google-protobuf version to 3.8.0

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ Development
 To build message classes, you'll need to install the latest version of
 [`protoc`](https://github.com/google/protobuf).
 
+To use the rbi_out option for sorbet interface file generation you'll need:
+https://github.com/coinbase/protoc-gen-rbi
+
 Build message classes: `rake compile`
 
 Run tests: `rake test`

--- a/lib/protip/tasks/compile.rake
+++ b/lib/protip/tasks/compile.rake
@@ -3,7 +3,7 @@ require 'bundler/setup'
 
 namespace :protip do
   desc 'compile a single .proto file to Ruby'
-  task :compile, [:filename, :proto_path, :ruby_path] do |t, args|
+  task :compile, [:filename, :proto_path, :ruby_path, :rbi_path, :protoc_gen_rbi_path] do |t, args|
     proto_path = [args[:proto_path] || 'definitions'].flatten.compact.reject{|path| path == ''}
     proto_path << File.join(Gem.loaded_specs['protip'].full_gem_path, 'definitions')
 
@@ -11,7 +11,10 @@ namespace :protip do
 
     filename = args[:filename] || raise(ArgumentError.new 'filename argument is required')
 
-    command = "bundle exec grpc_tools_ruby_protoc #{proto_path.map{|p| "--proto_path=#{Shellwords.escape p}"}.join ' '} --ruby_out=#{Shellwords.escape ruby_path} #{Shellwords.escape filename}"
+    command = "bundle exec grpc_tools_ruby_protoc #{proto_path.map{|p| "--proto_path=#{Shellwords.escape p}"}.join ' '} --ruby_out=#{Shellwords.escape ruby_path}"
+    command << " --plugin=protoc-gen-rbi=#{args[:protoc_gen_rbi_path]}" if args[:protoc_gen_rbi_path]
+    command << " --rbi_out=#{args[:rbi_path]}" if args[:rbi_path]
+    command << " #{Shellwords.escape filename}"
     puts command
     system command
 

--- a/lib/protip/version.rb
+++ b/lib/protip/version.rb
@@ -1,3 +1,3 @@
 module Protip
-  VERSION = '0.36'
+  VERSION = '0.36.1'
 end


### PR DESCRIPTION
Adding the option to use the protoc-gen-rbi plugin, gold standard for rbi protobuf generation. https://github.com/coinbase/protoc-gen-rbi

The build is failing for this gem already so i think it's just safe to ship this lol.
The task i modified is used in comptroller, so i'm adding options there, you can optionally set the plugin path in case the docker environments differ.

how do i upload this to gem fury?