### PR TITLE
Use BigDecimal#precision instead of BigDecimal#precs when available

### DIFF
--- a/lib/protip/transformers/big_decimal_transformer.rb
+++ b/lib/protip/transformers/big_decimal_transformer.rb
@@ -21,7 +21,7 @@ module Protip
               field.subtype.msgclass.new(
                 numerator: rational.numerator,
                 denominator: rational.denominator,
-                precision: object.precs[0], # This is the current precision of the decimal
+                precision: object.try(:precision) || object.precs[0], # This is the current precision of the decimal
               )
             end
           end).new

--- a/lib/protip/version.rb
+++ b/lib/protip/version.rb
@@ -1,3 +1,3 @@
 module Protip
-  VERSION = '0.37.4'
+  VERSION = '0.37.5'
 end


### PR DESCRIPTION
Ruby 3.3.1 moves this method into #precision and #n_significant_digits - `precs` gives wildly different results between versions/platforms, this is an important fix IMO.