### PR TITLE
Support protobuf maps

### DIFF
--- a/lib/protip/version.rb
+++ b/lib/protip/version.rb
@@ -1,3 +1,3 @@
 module Protip
-  VERSION = '0.38.0'
+  VERSION = '0.39.0'
 end


### PR DESCRIPTION
Adds support for decorating `map<keytype, valuetype>` fields. This required special handling since we were interpreting hashes as lists of proto field assignments in several places.