### PR TITLE
Handle maps in decorator#to_h

### DIFF
--- a/lib/protip/decorator.rb
+++ b/lib/protip/decorator.rb
@@ -178,11 +178,20 @@ module Protip
       message.class.descriptor.each do |field|
         value = get(field)
         if field.label == :repeated
-          value.map!{|v| transform[v]}
+          if Protip::Decorator.map_field?(field)
+            hash[field.name.to_sym] = {}
+
+            value.each do |k, v|
+              hash[field.name.to_sym][transform[k]] = transform[v]
+            end
+          else
+            value.map!{|v| transform[v]}
+            hash[field.name.to_sym] = value
+          end
         else
           value = transform[value]
+          hash[field.name.to_sym] = value
         end
-        hash[field.name.to_sym] = value
       end
       hash
     end

--- a/lib/protip/version.rb
+++ b/lib/protip/version.rb
@@ -1,3 +1,3 @@
 module Protip
-  VERSION = '0.39.0'
+  VERSION = '0.39.1'
 end


### PR DESCRIPTION
Followup to https://github.com/angellist/protip/pull/59

While auditing existing uses of `map` fields, I realized `to_h` also wasn't handling maps, which I missed in my first read.