### PR TITLE
Retry on connection failed

### DIFF
--- a/lib/protip/version.rb
+++ b/lib/protip/version.rb
@@ -1,3 +1,3 @@
 module Protip
-  VERSION = '0.39.1'
+  VERSION = '0.39.2'
 end

--- a/protip.gemspec
+++ b/protip.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'money', '>= 6.5.1', '< 7.0'
   spec.add_runtime_dependency 'google-protobuf', '>= 3.7.1'
   spec.add_runtime_dependency 'faraday', '< 3'
+  spec.add_runtime_dependency 'faraday-retry'
 
   spec.add_development_dependency 'grpc-tools', '1.48.0'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
Example:
> Retrying GET http://localhost:3000/api due to Faraday::ConnectionFailed
Retrying GET http://localhost:3000/api due to Faraday::ConnectionFailed
Faraday::ConnectionFailed: Connection refused - connect(2) for 127.0.0.1:3000
from /usr/local/bundle/gems/io-endpoint-0.15.2/lib/io/endpoint/wrapper.rb:58:in 'Socket#connect'
Caused by Errno::ECONNREFUSED: Connection refused - connect(2) for 127.0.0.1:3000
from /usr/local/bundle/gems/io-endpoint-0.15.2/lib/io/endpoint/wrapper.rb:58:in 'Socket#connect'

Tested patched into prod console, also with `test code` & `base_uri` additions:
```
retry_options = {
  max: 2,
  interval: 0.05, 
  interval_randomness: 0.5,
  backoff_factor: 2,
  exceptions: [
    Faraday::ConnectionFailed,
  ],    
  # test code: 
  methods: [],
  retry_if: ->(env, ex) { 
    puts "Retrying #{env.method.upcase} #{env.url} due to #{ex.class}"
    true  
  },    
} 
base_uri = 'http://localhost:3000'
```

Retries were [removed previously](https://github.com/angellist/protip/commit/fa16c6201a3e9641e8945e8b6529a0f87b5b79d2) due to the long timeout setting of 10 minutes, so not retrying on timeout exceptions.